### PR TITLE
Support New HF metadata Format

### DIFF
--- a/resources/resolver.go
+++ b/resources/resolver.go
@@ -97,10 +97,10 @@ func GetResourceEntries(typ ResourceType) ResourceEntryDefs {
 		}
 	case RESOURCETYPE_DIFFUSERS:
 		return ResourceEntryDefs{
-			"feature_extractor/preprocessor_config.json": RESOURCE_REQUIRED,
+			"feature_extractor/preprocessor_config.json": RESOURCE_OPTIONAL,
 			"safety_checker/config.json":                 RESOURCE_OPTIONAL,
-			"safety_checker/pytorch_model.json":          RESOURCE_OPTIONAL,
-			"scheduler/scheduler_config.json":            RESOURCE_OPTIONAL,
+			"safety_checker/pytorch_model.bin":           RESOURCE_OPTIONAL,
+			"scheduler/scheduler_config.json":            RESOURCE_REQUIRED,
 			"text_encoder/config.json":                   RESOURCE_REQUIRED,
 			"text_encoder/pytorch_model.bin":             RESOURCE_MODEL,
 			"tokenizer/merges.txt":                       RESOURCE_REQUIRED,
@@ -111,6 +111,7 @@ func GetResourceEntries(typ ResourceType) ResourceEntryDefs {
 			"unet/diffusion_pytorch_model.bin":           RESOURCE_MODEL,
 			"vae/config.json":                            RESOURCE_REQUIRED,
 			"vae/diffusion_pytorch_model.bin":            RESOURCE_MODEL,
+			"model_index.json":                           RESOURCE_REQUIRED,
 		}
 	default:
 		return ResourceEntryDefs{}

--- a/resources/resolver.go
+++ b/resources/resolver.go
@@ -379,9 +379,10 @@ func ResolveResources(
 		}
 	}
 
-	flagVocabNotExist := CheckFileDoesNotExist(path.Join(*dir, "vocab.json"))
+	flagVocabExist := CheckFileExist(path.Join(*dir, "vocab.json"))
 
-	if !flagVocabNotExist {
+	//if vocab does not exist, extract it from tokenizer
+	if !flagVocabExist {
 		model, err := ExtractModelFromTokenizer(dir)
 		if err != nil {
 			return &foundResources, errors.New(
@@ -397,9 +398,10 @@ func ResolveResources(
 		}
 	}
 
-	flagMergesNotExists := CheckFileDoesNotExist(path.Join(*dir, "merges.txt"))
+	flagMergesExists := CheckFileExist(path.Join(*dir, "merges.txt"))
 
-	if !flagMergesNotExists {
+	//if merges does not exist, extract it from tokenizer
+	if !flagMergesExists {
 		model, err := ExtractModelFromTokenizer(dir)
 		if err != nil {
 			return &foundResources, errors.New(
@@ -418,13 +420,13 @@ func ResolveResources(
 	return &foundResources, nil
 }
 
-func CheckFileDoesNotExist(path string) bool {
+func CheckFileExist(path string) bool {
 	_, err := os.Stat(path)
 
 	if errors.Is(err, os.ErrNotExist) {
-		return true
-	} else {
 		return false
+	} else {
+		return true
 	}
 }
 

--- a/resources/resolver.go
+++ b/resources/resolver.go
@@ -379,9 +379,9 @@ func ResolveResources(
 		}
 	}
 
-	flagVocabExists := CheckFileDoesNotExist(path.Join(*dir, "vocab.json"))
+	flagVocabNotExist := CheckFileDoesNotExist(path.Join(*dir, "vocab.json"))
 
-	if flagVocabExists {
+	if !flagVocabNotExist {
 		model, err := ExtractModelFromTokenizer(dir)
 		if err != nil {
 			return &foundResources, errors.New(
@@ -397,9 +397,9 @@ func ResolveResources(
 		}
 	}
 
-	flagMergesExists := CheckFileDoesNotExist(path.Join(*dir, "merges.txt"))
+	flagMergesNotExists := CheckFileDoesNotExist(path.Join(*dir, "merges.txt"))
 
-	if flagMergesExists {
+	if !flagMergesNotExists {
 		model, err := ExtractModelFromTokenizer(dir)
 		if err != nil {
 			return &foundResources, errors.New(

--- a/resources/resolver.go
+++ b/resources/resolver.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/dustin/go-humanize"
 	"io"
 	"io/fs"
 	"io/ioutil"
@@ -13,6 +12,8 @@ import (
 	"os"
 	"path"
 	"time"
+
+	"github.com/dustin/go-humanize"
 )
 
 type ResourceFlag uint8
@@ -84,22 +85,22 @@ func GetResourceEntries(typ ResourceType) ResourceEntryDefs {
 	case RESOURCETYPE_TRANSFORMERS:
 		return ResourceEntryDefs{
 			"config.json":             RESOURCE_REQUIRED,
-			"vocab.json":              RESOURCE_REQUIRED,
-			"merges.txt":              RESOURCE_REQUIRED,
+			"vocab.json":              RESOURCE_OPTIONAL,
+			"merges.txt":              RESOURCE_OPTIONAL,
 			"special_tokens_map.json": RESOURCE_OPTIONAL,
 			"unitrim.json":            RESOURCE_OPTIONAL,
 			"wordtokens.json":         RESOURCE_OPTIONAL,
 			"specials.txt":            RESOURCE_OPTIONAL | RESOURCE_DERIVED,
 			"tokenizer_config.json":   RESOURCE_OPTIONAL,
-			"tokenizer.json":          RESOURCE_OPTIONAL,
+			"tokenizer.json":          RESOURCE_REQUIRED,
 			"pytorch_model.bin":       RESOURCE_MODEL,
 		}
 	case RESOURCETYPE_DIFFUSERS:
 		return ResourceEntryDefs{
-			"feature_extractor/preprocessor_config.json": RESOURCE_OPTIONAL,
+			"feature_extractor/preprocessor_config.json": RESOURCE_REQUIRED,
 			"safety_checker/config.json":                 RESOURCE_OPTIONAL,
-			"safety_checker/pytorch_model.bin":           RESOURCE_OPTIONAL,
-			"scheduler/scheduler_config.json":            RESOURCE_REQUIRED,
+			"safety_checker/pytorch_model.json":          RESOURCE_OPTIONAL,
+			"scheduler/scheduler_config.json":            RESOURCE_OPTIONAL,
 			"text_encoder/config.json":                   RESOURCE_REQUIRED,
 			"text_encoder/pytorch_model.bin":             RESOURCE_MODEL,
 			"tokenizer/merges.txt":                       RESOURCE_REQUIRED,
@@ -110,7 +111,6 @@ func GetResourceEntries(typ ResourceType) ResourceEntryDefs {
 			"unet/diffusion_pytorch_model.bin":           RESOURCE_MODEL,
 			"vae/config.json":                            RESOURCE_REQUIRED,
 			"vae/diffusion_pytorch_model.bin":            RESOURCE_MODEL,
-			"model_index.json":                           RESOURCE_REQUIRED,
 		}
 	default:
 		return ResourceEntryDefs{}
@@ -194,27 +194,27 @@ func (rsrcs *Resources) AddEntry(name string, file *os.File) error {
 }
 
 // Specials
-// Map of special tokens such as `<|pad|>`, `<|endoftext|>`, etc.
+// Map of special tokens such as <|pad|>, <|endoftext|>, etc.
 type Specials map[string]string
 
 // ResolveSpecialTokens
-// If `specials.json` does not exist in `dir`, create it from the
-// `special_tokens_map.json` file.
+// If specials.json does not exist in dir, create it from the
+// special_tokens_map.json file.
 func (rsrcs *Resources) ResolveSpecialTokens(dir string) (
 	realizedSpecials Specials, err error) {
 	realizedSpecials = make(Specials, 0)
-	// If we already have `specials.json`, we don't need to generate it.
+	// If we already have specials.json, we don't need to generate it.
 	if _, ok := (*rsrcs)["specials.json"]; ok {
 		if specErr := json.Unmarshal(*(*rsrcs)["specials.json"].Data,
 			&realizedSpecials); specErr != nil {
 			return nil, errors.New(
-				fmt.Sprintf("cannot unmarshal `specials.json`: %s",
+				fmt.Sprintf("cannot unmarshal specials.json: %s",
 					specErr))
 		}
 		return realizedSpecials, nil
 	}
 
-	// We can only generate `specials.json` if we have `special_tokens_map`
+	// We can only generate specials.json if we have special_tokens_map
 	specialsJson, ok := (*rsrcs)["special_tokens_map.json"]
 	if !ok {
 		return nil, nil
@@ -252,26 +252,26 @@ func (rsrcs *Resources) ResolveSpecialTokens(dir string) (
 			os.O_TRUNC|os.O_RDWR|os.O_CREATE, 0755)
 		if specialFileErr != nil {
 			return nil, errors.New(
-				fmt.Sprintf("cannot generate `specials.json`: %s",
+				fmt.Sprintf("cannot generate specials.json: %s",
 					specialFileErr))
 		}
 		specialsJsonBytes, specialsErr := json.Marshal(realizedSpecials)
 		if specialsErr != nil {
 			specialsFile.Close()
 			return nil, errors.New(
-				fmt.Sprintf("cannot marshal `specials.json`: %s",
+				fmt.Sprintf("cannot marshal specials.json: %s",
 					specialsErr))
 		}
 		if _, writeErr := specialsFile.Write(
 			specialsJsonBytes); writeErr != nil {
 			specialsFile.Close()
 			return nil, errors.New(
-				fmt.Sprintf("cannot write `specials.json`: %s",
+				fmt.Sprintf("cannot write specials.json: %s",
 					specialsErr))
 		}
 		if _, seekErr := specialsFile.Seek(0, 0); seekErr != nil {
 			return nil, errors.New(
-				fmt.Sprintf("cannot seek `specials.json`: %s",
+				fmt.Sprintf("cannot seek specials.json: %s",
 					seekErr))
 		}
 		if mmapErr := rsrcs.AddEntry("specials.json",
@@ -309,7 +309,7 @@ func ResolveResources(
 						uri, file)
 					return &foundResources, errors.New(
 						fmt.Sprintf(
-							"cannot retrieve required `%s` from `%s`: %s",
+							"cannot retrieve required `%s from %s`: %s",
 							uri, file, rsrcSizeErr))
 				} else {
 					log.Printf("Resolved %s/%s... not there, not required.",
@@ -333,7 +333,7 @@ func ResolveResources(
 			} else if rsrcReader, rsrcErr := Fetch(uri, file, token); rsrcErr != nil {
 				return &foundResources, errors.New(
 					fmt.Sprintf(
-						"cannot retrieve `%s` from `%s`: %s",
+						"cannot retrieve `%s from %s`: %s",
 						uri, file, rsrcErr))
 			} else {
 				if dirErr := os.MkdirAll(
@@ -377,7 +377,54 @@ func ResolveResources(
 			}
 		}
 	}
+
+	flagVocabExists := CheckFileDoesNotExist(path.Join(*dir, "vocab.json"))
+
+	if flagVocabExists {
+		model, err := ExtractModelFromTokenizer(dir)
+		if err != nil {
+			return &foundResources, errors.New(
+				fmt.Sprintf("Could not extract model from tokenizer %s",
+					err))
+		}
+
+		err = ExtractVocabFromTokenizer(model, dir)
+		if err != nil {
+			return &foundResources, errors.New(
+				fmt.Sprintf("Could not extract vocab from tokenizer %s",
+					err))
+		}
+	}
+
+	flagMergesExists := CheckFileDoesNotExist(path.Join(*dir, "merges.txt"))
+
+	if flagMergesExists {
+		model, err := ExtractModelFromTokenizer(dir)
+		if err != nil {
+			return &foundResources, errors.New(
+				fmt.Sprintf("Could not extract model from tokenizer %s",
+					err))
+		}
+
+		err = ExtractMergesFromTokenizer(model, dir)
+		if err != nil {
+			return &foundResources, errors.New(
+				fmt.Sprintf("Could not extract merges from tokenizer %s",
+					err))
+		}
+	}
+
 	return &foundResources, nil
+}
+
+func CheckFileDoesNotExist(path string) bool {
+	_, err := os.Stat(path)
+
+	if errors.Is(err, os.ErrNotExist) {
+		return true
+	} else {
+		return false
+	}
 }
 
 // HFConfig contains the tokenizer configuration that gpt_bpe uses.
@@ -432,7 +479,7 @@ func ResolveConfig(vocabId string, token string) (config *HFConfig,
 		&hfConfig); configErr != nil {
 		resources.Cleanup()
 		return nil, nil, errors.New(fmt.Sprintf(
-			"error unmarshalling `config.json`: %s", configErr))
+			"error unmarshalling config.json: %s", configErr))
 	}
 
 	specialTokens, specialsErr := resources.ResolveSpecialTokens(dir)
@@ -529,4 +576,106 @@ func ResolveVocabId(vocabId string, token string) (*HFConfig, *Resources, error)
 		}
 		return config, resources, nil
 	}
+}
+
+func ExtractModelFromTokenizer(dir *string) (map[string]interface{}, error) {
+	tokenizerPath := path.Join(*dir, "tokenizer.json")
+	// Open the file
+	tokenizerFile, err := os.Open(tokenizerPath)
+	if err != nil {
+		log.Println("Error opening tokenizer:", err)
+		// return an empty map and the error
+		return nil, err
+	}
+	defer tokenizerFile.Close()
+
+	// Decode the JSON data into a map
+	var data map[string]interface{}
+	err = json.NewDecoder(tokenizerFile).Decode(&data)
+	if err != nil {
+		log.Println("Error decoding JSON from tokenizer:", err)
+		return nil, err
+	}
+
+	// Access the data at the specified path
+	model, ok := data["model"].(map[string]interface{})
+	if ok {
+		return model, nil
+	} else {
+		log.Println("Error: Could not convert model in tokenizer to map")
+		return nil, errors.New("Could not convert model in tokenizer to map")
+	}
+}
+
+func ExtractVocabFromTokenizer(model map[string]interface{}, dir *string) error {
+	vocab, ok := model["vocab"].(map[string]interface{})
+	if !ok {
+		log.Println("Error: Could not convert vocab in model to map")
+		return errors.New("Could not convert vocab in model to map")
+	}
+
+	vocabPath := path.Join(*dir, "vocab.json")
+
+	// Create the file
+	vocabFile, err := os.Create(vocabPath)
+	if err != nil {
+		log.Println("Error creating vocab.json:", err)
+		return err
+	}
+	defer vocabFile.Close()
+
+	// Marshal the vocab map into a JSON string with indentation
+	vocabJsonString, err := json.MarshalIndent(vocab, "", " ")
+	if err != nil {
+		fmt.Println("Error marshaling JSON:", err)
+		return err
+	}
+
+	// Write the JSON string to the file
+	_, err = vocabFile.Write(vocabJsonString)
+	if err != nil {
+		log.Println("Error writing to vocab.json:", err)
+		return err
+	}
+
+	log.Println("Vocab written to vocab.json from tokenizer.json")
+
+	return nil
+}
+
+func ExtractMergesFromTokenizer(model map[string]interface{}, dir *string) error {
+	merges, ok := model["merges"].([]interface{})
+	if !ok {
+		log.Println("Error: Could not convert merges in model to map")
+		return errors.New("Could not convert merges in model to map")
+	}
+
+	// Convert the slice of interfaces to a slice of strings
+	var mergesStr []string
+	for _, v := range merges {
+		mergesStr = append(mergesStr, v.(string))
+	}
+
+	mergesPath := path.Join(*dir, "merges.txt")
+
+	// Create the file
+	mergesFile, err := os.Create(mergesPath)
+	if err != nil {
+		log.Println("Error creating file:", err)
+		return err
+	}
+	defer mergesFile.Close()
+
+	// Write each merge string to a new line in the file
+	for _, v := range merges {
+		_, err = mergesFile.WriteString(v.(string) + "\n")
+		if err != nil {
+			log.Println("Error writing to file:", err)
+			return err
+		}
+	}
+
+	log.Println("Merges written to merges.txt from tokenizer.json")
+
+	return nil
 }


### PR DESCRIPTION
gpt_bpe Repo -- model downloader.

Pythia models from ElutherAI now follows the new HF metadata format for transformer models, where the merges.txt and vocab.json is folded into the tokenizer.json file under a key entry each. This PR will check for this new format and attempt to unfold the json data (ie generate a separate vocab.json, merges.txt) from the tokenizer.json file, allowing for direct HF support for pythia models and others of similar formats.

Work was done jointly by Rex and Rahul.