### PR TITLE
Rwang.fairseq

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 )
 
 require (
-	github.com/dustin/go-humanize v1.0.0
+	github.com/dustin/go-humanize v1.0.1
 	github.com/gopherjs/gopherjs v1.17.2
 	github.com/jdkato/prose/v2 v2.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/deckarep/golang-set v1.8.0 h1:sk9/l/KqpunDwP7pSjUg0keiOOLEnOBHzykLrsP
 github.com/deckarep/golang-set v1.8.0/go.mod h1:5nI87KwE7wgsBU1F4GKAw2Qod7p5kyS383rP6+o6qqo=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
 github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/gpt_bpe_test.go
+++ b/gpt_bpe_test.go
@@ -805,7 +805,7 @@ func TestModelDownloadPythiaSharded(t *testing.T) {
 	// This tests the model downloader's ability
 	// to download a sharded model.
 
-	modelId := "EleutherAI/pythia-6.9b"
+	modelId := "EleutherAI/pythia-6.9b-deduped"
 	destPath := "./TestModelDownloadPythiaSharded"
 	destPathPTR := &destPath
 
@@ -871,4 +871,87 @@ func TestModelDownloadPythiaSharded(t *testing.T) {
 	os.RemoveAll(destPath)
 	fmt.Println("All Exists - Looks good.")
 
+}
+
+func TestModelDownloadFairseq(t *testing.T) {
+	// Koboldai's fairseq models are stored in a different format
+	// it has merges and vocab but no tokenizer.json
+	modelId := "KoboldAI/fairseq-dense-355M"
+	destPath := "./TestModelDownloadFairseq"
+	destPathPTR := &destPath
+
+	var rsrcType resources.ResourceType
+	rsrcType = resources.RESOURCETYPE_TRANSFORMERS
+	hfApiToken := os.Getenv("HF_API_TOKEN")
+	os.MkdirAll(destPath, 0755)
+	_, rsrcErr := resources.ResolveResources(modelId, destPathPTR,
+		resources.RESOURCE_MODEL, rsrcType, hfApiToken)
+	if rsrcErr != nil {
+		os.RemoveAll(destPath)
+		t.Errorf("Error downloading model resources: %s", rsrcErr)
+	}
+
+	// Check that the model files are there
+	// We want to check for the presence of the following files:
+	// vocab, config. merges, pytorch_model
+
+	// Check for config.json
+	configPath := destPath + "/config.json"
+	if _, err := os.Stat(configPath); err == nil {
+		fmt.Println("config.json exists")
+
+	} else if errors.Is(err, os.ErrNotExist) {
+		os.RemoveAll(destPath)
+		t.Errorf("config.json does not exist")
+
+	} else {
+		os.RemoveAll(destPath)
+		t.Errorf("Error checking for config.json")
+	}
+
+	// Check for pytorch_model.bin
+	modelPath := destPath + "/pytorch_model.bin"
+	if _, err := os.Stat(modelPath); err == nil {
+		fmt.Println("pytorch_model.bin exists")
+
+	} else if errors.Is(err, os.ErrNotExist) {
+		os.RemoveAll(destPath)
+		t.Errorf("pytorch_model.bin does not exist")
+
+	} else {
+		os.RemoveAll(destPath)
+		t.Errorf("Error checking for pytorch_model.bin")
+	}
+
+	// Check for vocab.json
+	vocabPath := destPath + "/vocab.json"
+	if _, err := os.Stat(vocabPath); err == nil {
+		fmt.Println("vocab.json exists")
+
+	} else if errors.Is(err, os.ErrNotExist) {
+		os.RemoveAll(destPath)
+		t.Errorf("vocab.json does not exist")
+
+	} else {
+		os.RemoveAll(destPath)
+		t.Errorf("Error checking for vocab.json")
+	}
+
+	// Check for merges.txt
+	mergesPath := destPath + "/merges.txt"
+	if _, err := os.Stat(mergesPath); err == nil {
+		fmt.Println("merges.txt exists")
+
+	} else if errors.Is(err, os.ErrNotExist) {
+		os.RemoveAll(destPath)
+		t.Errorf("merges.txt does not exist")
+
+	} else {
+		os.RemoveAll(destPath)
+		t.Errorf("Error checking for merges.txt")
+	}
+
+	// Clean up by removing the downloaded folder
+	os.RemoveAll(destPath)
+	fmt.Println("All Exists - Looks good (Fairseq Download).")
 }

--- a/resources/resolver.go
+++ b/resources/resolver.go
@@ -541,6 +541,11 @@ func ResolveResources(
 				err = rsrcReader.Close()
 				if err != nil {
 					return &foundResources, errors.New(
+						fmt.Sprintf("error trying to close file: %s",
+							err))
+				}
+				if err != nil {
+					return &foundResources, errors.New(
 						fmt.Sprintf("error trying to close reader: %s",
 							err))
 				}
@@ -552,14 +557,6 @@ func ResolveResources(
 					log.Println(fmt.Sprintf("Downloaded %s/%s... "+
 						"%s completed.", uri, shardPath,
 						humanize.Bytes(uint64(bytesDownloaded))))
-				}
-
-				//close shard file
-				err = rsrcFile.Close()
-				if err != nil {
-					return &foundResources, errors.New(
-						fmt.Sprintf("error trying to close file: %s",
-							err))
 				}
 
 				//check if shard local size is correct compared to remote size
@@ -734,10 +731,6 @@ func ResolveVocabId(vocabId string, token string) (*HFConfig, *Resources, error)
 		return nil, nil, err
 	} else {
 		config.ModelId = &resolvedVocabId
-		if _, exists := (*resources)["unitrim.json"]; !exists {
-			(*resources)["unitrim.json"] = *GetEmbeddedResource(
-				"gpt2-tokenizer/unitrim.json")
-		}
 		if _, exists := (*resources)["encoder.json"]; !exists {
 			(*resources)["encoder.json"] = *GetEmbeddedResource(
 				"gpt2-tokenizer/encoder.json")

--- a/resources/resolver.go
+++ b/resources/resolver.go
@@ -507,7 +507,13 @@ func ResolveResources(
 				}
 				bytesDownloaded, ioErr := io.Copy(&rsrcFile,
 					io.TeeReader(rsrcReader, counter))
-				rsrcReader.Close()
+				//close shard reader
+				err = rsrcReader.Close()
+				if err != nil {
+					return &foundResources, errors.New(
+						fmt.Sprintf("error trying to close reader: %s",
+							err))
+				}
 				if ioErr != nil {
 					return &foundResources, errors.New(
 						fmt.Sprintf("error downloading '%s': %s",
@@ -523,14 +529,6 @@ func ResolveResources(
 				if err != nil {
 					return &foundResources, errors.New(
 						fmt.Sprintf("error trying to close file: %s",
-							err))
-				}
-
-				//close shard reader
-				err = rsrcReader.Close()
-				if err != nil {
-					return &foundResources, errors.New(
-						fmt.Sprintf("error trying to close reader: %s",
 							err))
 				}
 


### PR DESCRIPTION
Fairseq uses a format where the merges and vocab is provided but the tokenizer.json is not. We mark tokenizer.json as optional, and allow it to pass if both merges and vocab is present. If it isn't present and the tokenizer is present, we try and extract them from the tokenizer.json. If neither are present, we error out.