### PR TITLE
Stop clip decode ahead of time

### DIFF
--- a/gpt_bpe_test.go
+++ b/gpt_bpe_test.go
@@ -515,7 +515,6 @@ func TestCLIPEncoder_Decode(t *testing.T) {
 		}
 
 		if clipCorpus[idx] != decoded[idx] {
-			log.Printf("Index %v: %v != %v\n", idx, clipCorpus[idx], decoded[idx])
 			t.Errorf("%v != %v", clipCorpus[idx-20:idx+20],
 				decoded[idx-20:idx+20])
 			return

--- a/gpt_bpe_test.go
+++ b/gpt_bpe_test.go
@@ -496,7 +496,7 @@ func TestGPTEncoder_Decode(t *testing.T) {
 // clipCorpus to be different from the corpus.  This is a bug in
 // the CLIP tokenizer from huggingface that was used to generate
 // the clipCorpus. The decoded corpus is correct in this test.
-
+// We stop the test right before the bug.
 func TestCLIPEncoder_Decode(t *testing.T) {
 	if clipEncoded == nil {
 		corpEncoded := clipEncoder.Encode(&corpus)
@@ -506,10 +506,16 @@ func TestCLIPEncoder_Decode(t *testing.T) {
 	decoded := clipEncoder.Decode(clipEncoded)
 	duration := time.Since(start)
 	tokenNumBytes := len(decoded)
+	idxToStop := 229550
 	t.Log(fmt.Sprintf("%v tokens into %v bytes over %v\n",
 		len(*clipEncoded), tokenNumBytes, duration))
 	for idx := range clipCorpus {
+		if idx > idxToStop {
+			break
+		}
+
 		if clipCorpus[idx] != decoded[idx] {
+			log.Printf("Index %v: %v != %v\n", idx, clipCorpus[idx], decoded[idx])
 			t.Errorf("%v != %v", clipCorpus[idx-20:idx+20],
 				decoded[idx-20:idx+20])
 			return


### PR DESCRIPTION
Added pre-emptive stop for CLIP test that fails due to a bug.