### PR TITLE
fix: Fix `encoder.json` handling and unitrim array generation

### DIFF
--- a/cmd/model_downloader/model_resolver.go
+++ b/cmd/model_downloader/model_resolver.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"github.com/wbrown/gpt_bpe/resources"
 	"log"
 	"os"
@@ -10,7 +9,7 @@ import (
 
 func main() {
 	modelId := flag.String("model", "",
-		"model URL, path, or huggingface id to fetch")
+		"model URL, path, or HuggingFace id to fetch")
 	destPath := flag.String("dest", "./",
 		"where to download the model to")
 	modelType := flag.String("type", "transformers",
@@ -45,10 +44,12 @@ func main() {
 	// get HF_API_TOKEN from env for huggingface auth
 	hfApiToken := os.Getenv("HF_API_TOKEN")
 
-	os.MkdirAll(*destPath, 0755)
+	if mkdirErr := os.MkdirAll(*destPath, 0755); mkdirErr != nil {
+		log.Fatalf("Error creating output directory: %s", mkdirErr)
+	}
 	_, rsrcErr := resources.ResolveResources(*modelId, destPath,
 		rsrcLvl, rsrcType, hfApiToken)
 	if rsrcErr != nil {
-		fmt.Sprintf("Error downloading model resources: %s", rsrcErr)
+		log.Fatalf("Error downloading model resources: %s", rsrcErr)
 	}
 }

--- a/gpt_bpe.go
+++ b/gpt_bpe.go
@@ -192,30 +192,7 @@ func NewEncoder(vocabId string) (*GPTEncoder, error) {
 	unitrimArr := makeUnitrimArr(encoderMappings)
 
 	// Build the bytes to unicode tables.
-	bytesUnicodeMap := make(map[byte]rune)
-	unicodeBytes := make(map[rune]byte)
-	for b := uint8('!'); b < uint8('~')+1; b++ {
-		bytesUnicodeMap[b] = rune(b)
-		unicodeBytes[rune(b)] = b
-	}
-	for b := uint8('¡'); b < uint8('¬')+1; b++ {
-		bytesUnicodeMap[b] = rune(b)
-		unicodeBytes[rune(b)] = b
-	}
-	for b := uint16('®'); b < uint16('ÿ')+1; b++ {
-		bytesUnicodeMap[byte(b)] = rune(b)
-		unicodeBytes[rune(b)] = byte(b)
-	}
-	uct := 0
-	var bytesUnicode [256]rune
-	for b := Token(0); b < 256; b++ {
-		if _, ok := bytesUnicodeMap[uint8(b)]; !ok {
-			bytesUnicodeMap[uint8(b)] = rune(256 + uct)
-			unicodeBytes[rune(256+uct)] = uint8(b)
-			uct += 1
-		}
-		bytesUnicode[b] = bytesUnicodeMap[uint8(b)]
-	}
+	bytesUnicode, unicodeBytes := makeByteTranslationTables()
 
 	// Go through the encoderMappings for possible byte runes.
 	// Read Encoder mappings and also generate reverse mappings.
@@ -394,143 +371,136 @@ func (encoder *GPTEncoder) UpdateSpecialsTree() {
 	encoder.SpecialsTree = CreateRuneTree(specialsArr)
 }
 
-// makeUnitrimArr creates a lookup table for unicode trimming
-// it replaces the method of generating it in advanced (unitrim.json)
+// makeByteTranslationTables creates lookup tables for interconverting
+// between runes in decoded token strings and the UTF-8 byte sequences
+// that they encode.
+func makeByteTranslationTables() ([256]rune, map[rune]byte) {
+	// GPT2's BPE implementation reinterprets UTF-8-encoded bytes as
+	// Unicode codepoints, but remaps the 68 code points
+	// corresponding to control, format, and space-separator characters
+	// (i.e. Unicode character categories Cc, Cf, and Zs)
+	// in the range [0, 255] to sequential codepoints in [256, 323],
+	// which happens to contain no characters from those three categories.
+	// For example, the byte \x00 is mapped to codepoint 256, and the final
+	// affected byte \xAD is mapped to codepoint 323.
+	// The remapped bytes are sequential even though the original bytes
+	// are not. The original bytes' codepoint interpretations all fall
+	// in the following ranges:
+	// - [\x00, \x20] ('NUL' to 'SPACE'; up to right before '!'),
+	// - [\x7F, \xA0] ('DELETE' to 'NO-BREAK SPACE'; between '~' and '¡')
+	// - \xAD exactly ('SOFT HYPHEN')
+	// Refer to "src/encoder.py" in the openai/gpt-2 repository for
+	// more detail.
+
+	byteDecoderMap := make(map[rune]byte, 256)
+	var byteEncoderLUT [256]rune
+
+	for i, relocated := rune(0), rune(256); i < 256; i++ {
+		relocatedByte := i
+		if i < '!' || i > '~' && i < '¡' || i == '\xAD' {
+			relocatedByte = relocated
+			relocated++
+		}
+		byteEncoderLUT[i] = relocatedByte
+		byteDecoderMap[relocatedByte] = byte(i)
+	}
+
+	return byteEncoderLUT, byteDecoderMap
+}
+
+// makeUnitrimArr creates a lookup table for trimming token sequences
+// to valid UTF-8 boundaries. It replaces unitrim.json files generated
+// in advance.
 func makeUnitrimArr(encoderMap map[string]Token) []int {
-	// get reverse mappings
-	reverseEncoderMap := make(map[Token]string)
-	for k, v := range encoderMap {
-		reverseEncoderMap[v] = k
-	}
+	// In order to check how many UTF-8 continuation bytes are missing from
+	// each individual token, the decoded token strings need to be translated
+	// to UTF-8.
+	_, byteDecoderMap := makeByteTranslationTables()
 
-	//make the maps needed
-	preMapList := make([]int, 512)
-	for i := 0; i < 512; i++ {
-		preMapList[i] = -1
-	}
-	postMapList := make([]int, 512)
+	// This function returns the following LUT, representing either
+	// how many continuation bytes are needed following a given token,
+	// or how many continuation bytes a given token fulfills.
+	// Positive entries require that many more continuation bytes to follow;
+	// negative entries fulfill that many continuation bytes.
+	debtLUT := make([]int, len(encoderMap))
 
-	// fill the maps with the unicode values
-	postMapIdx, preMapIdx := 0, 0
-	for i := uint8('!'); i < uint8('~')+1; i++ {
-		preMapList[preMapIdx] = int(i)
-		preMapIdx += 1
-	}
-	for i := uint8('¡'); i < uint8('¬')+1; i++ {
-		preMapList[preMapIdx] = int(i)
-		preMapIdx += 1
-	}
-	for i := uint16('®'); i < uint16('ÿ')+1; i++ {
-		preMapList[preMapIdx] = int(i)
-		preMapIdx += 1
-	}
-	copy(postMapList, preMapList)
-	postMapIdx = preMapIdx
-
-	for i := 0; i < 256; i++ {
-		// if the value is not in the remapping list
-		if !intInSlice(i, preMapList) {
-			preMapList[preMapIdx] = i
-			preMapIdx += 1
+	// Continuation byte requirements are defined by the UTF-8 standard
+	// and can be determined from bit patterns of each byte. We make a
+	// LUT of bit patterns to make this calculation faster.
+	// Only the 5 most significant bits are relevant.
+	var byteDebtLUT [32]int8
+	for b := 0; b <= 0b11110; b++ {
+		// According to UTF-8 variable-length binary encoding:
+		if (b & 0b10000) == 0 {
+			// All 7-bit ASCII characters have the bit pattern 0xxxxxxx
+			// - They are self-contained, and require no continuation
+			// - They are the only characters encoded with a single byte
+			byteDebtLUT[b] = 0
+		} else if (b & 0b11100) == 0b11000 {
+			// All 2-byte characters start with a 110xxxxx byte
+			// - These add +1 continuation byte debt
+			byteDebtLUT[b] = 1
+		} else if (b & 0b11110) == 0b11100 {
+			// All 3-byte characters start with a 1110xxxx byte
+			// - These add +2 continuation byte debt
+			byteDebtLUT[b] = 2
+		} else if (b & 0b11110) == 0b11110 {
+			// All 4-byte characters start with a 11110xxx byte
+			// - These add +3 continuation byte debt
+			// - No valid Unicode starts with 11111xxx, so the last
+			//   0 should be redundant, but some tokenizers include
+			//   such bytes in their vocabularies regardless.
+			byteDebtLUT[b] = 3
+		} else if (b & 0b11000) == 0b10000 {
+			// All continuation characters start with a 10xxxxxx byte
+			//- These satisfy (-) 1 continuation byte debt
+			byteDebtLUT[b] = -1
 		}
 	}
-	preMapIdx = 0
 
-	for i := 0; postMapIdx+i < 256; i++ {
-		// continue incrementing until end of list
-		if postMapList[postMapIdx+i] == -1 {
-			postMapList[postMapIdx+i] = preMapList[postMapIdx+i]
-			preMapList[postMapIdx+i] = preMapIdx + 256
-			preMapIdx += 1
+	// Calculate the debtLUT entries for each token ID
+	for decodedToken, token := range encoderMap {
+		tokenDebt := 0
+		minTokenDebt := 0
+
+		// Decode each Unicode codepoint into a UTF-8 byte
+		codepoints := []rune(decodedToken)
+		utf8Bytes := make([]byte, len(codepoints))
+		for i, c := range codepoints {
+			utf8Bytes[i] = byteDecoderMap[c]
 		}
 
-	}
-
-	// map int to rune
-	charMap := make(map[int]rune)
-	for i := 0; i < len(postMapList); i++ {
-		charMap[postMapList[i]] = rune(postMapList[i])
-	}
-
-	// create the decode map
-	DecodeMap := make(map[rune]int)
-	for i := 0; i < 256; i++ {
-		value := postMapList[i]
-		key := rune(preMapList[i])
-		DecodeMap[key] = value
-	}
-
-	// create the ordered array of encodings
-	orderedArrayEncodings := make([]string, len(reverseEncoderMap))
-	for k, v := range reverseEncoderMap {
-		orderedArrayEncodings[k] = v
-	}
-
-	// create the need array (returned by this function)
-	needArray := make([]int, 0)
-
-	// for each encoding, get the need
-	for i := 0; i < len(orderedArrayEncodings); i++ {
-		need := 0
-		min_need := 0
-
-		// apply mapping
-		v := DecodeMapping(reverseEncoderMap, DecodeMap, i)
-		// get binary representation of each character
-		// and match it to the need
-		for _, c := range v {
-			if (c & 0b10000000) == 0 {
-				need = 0
-			} else if (c & 0b11000000) == 0b10000000 {
-				need -= 1
-			} else if (c & 0b11100000) == 0b11000000 {
-				need = 1
-			} else if (c & 0b11110000) == 0b11100000 {
-				need = 2
-			} else if (c & 0b11111000) == 0b11110000 {
-				need = 3
-			}
-			if need < 0 {
-				min_need = need
+		// Keep track of continuation byte requirements
+		// between each UTF-8 byte.
+		for _, b := range utf8Bytes {
+			b >>= 3 // trim to relevant bits
+			byteDebt := int(byteDebtLUT[b])
+			if byteDebt < 0 {
+				// Continuation bytes are tracked relative to the bytes preceding them
+				tokenDebt += byteDebt
+			} else {
+				// Starting bytes have no relation to the bytes preceding them
+				tokenDebt = byteDebt
 			}
 
-			if need == 0 {
-				need = min_need
+			if tokenDebt < 0 {
+				minTokenDebt = tokenDebt
+			} else if tokenDebt == 0 {
+				// If the beginning of the string satisfies continuation
+				// byte debt, don't forget that just to track less-important
+				// information about self-contained byte sequences that follow.
+				// Do overwrite it if it ends with fresh debt.
+				// NB: if a token both satisfies continuation byte debt
+				// and then begins new debt, only the latter can be tracked.
+				// This is a limitation of the LUT entries being single
+				// integers rather than pairs of integers.
+				tokenDebt = minTokenDebt
 			}
 		}
-		needArray = append(needArray, need)
+		debtLUT[token] = tokenDebt
 	}
 
-	return needArray
-}
-
-// helper for makeUnitrimArr
-func DecodeMapping(
-	encodings map[Token]string,
-	mappings map[rune]int,
-	input int,
-) string {
-	// get original encoding
-	encoding := encodings[Token(input)]
-
-	// decode encoding by character
-	output_str := ""
-	for _, c := range encoding {
-		// get the mapping for the character
-		mapped := mappings[c]
-		output_str += fmt.Sprintf("%c", mapped)
-	}
-	return output_str
-}
-
-// helper for makeUnitrimArr
-func intInSlice(a int, list []int) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
+	return debtLUT
 }
 
 // insertAt inserts v into s at index i and returns the new slice.

--- a/gpt_bpe_test.go
+++ b/gpt_bpe_test.go
@@ -623,7 +623,7 @@ func TestGPTEncoder_Decode(t *testing.T) {
 	assert.Equal(t, corpus, decoded)
 }
 
-//BUG: CLIP TOKENIZER has a bug that causes 'the to be split into
+// BUG: CLIP TOKENIZER has a bug that causes 'the to be split into
 // "'t<w>he<w>" instead of "'<w>the<w>".  This causes the
 // clipCorpus to be different from the corpus.  This is a bug in
 // the CLIP tokenizer from huggingface that was used to generate
@@ -716,55 +716,55 @@ func TestGPTEncoder_TokensReadyContext(t *testing.T) {
 }
 
 func TestUnitrimFunctionality(t *testing.T) {
-	// get need array for gpt2 unitrim
-	encoderFile := "resources/data/clip-tokenizer/encoder.json"
-	unitrimFile := "resources/data/clip-tokenizer/unitrim.json"
+	for _, tokenizer := range []string{"clip-tokenizer", "gpt2-tokenizer", "pile-tokenizer"} {
+		encoderFile := fmt.Sprintf("resources/data/%s/encoder.json", tokenizer)
+		unitrimFile := fmt.Sprintf("resources/data/%s/unitrim.json", tokenizer)
 
-	// make sure the files exist
-	if _, err := os.Stat(encoderFile); os.IsNotExist(err) {
-		t.Errorf("Could not find file %s\n", encoderFile)
-	}
-	if _, err := os.Stat(unitrimFile); os.IsNotExist(err) {
-		t.Errorf("Could not find file %s\n", unitrimFile)
-	}
-
-	// read in the Encoder and unitrim files
-	encoderBytes, err := os.ReadFile(encoderFile)
-	// unmarshal the Encoder file
-	var encoder map[string]Token
-	err = json.Unmarshal(encoderBytes, &encoder)
-	if err != nil {
-		t.Errorf("Could not unmarshal Encoder file: %v\n", err)
-	}
-
-	// read in the unitrim file
-	unitrimBytes, err := os.ReadFile(unitrimFile)
-	// unmarshal the unitrim file
-	var unitrim []int
-	err = json.Unmarshal(unitrimBytes, &unitrim)
-	if err != nil {
-		t.Errorf("Could not unmarshal unitrim file: %v\n", err)
-	}
-
-	// get need array for gpt2 unitrim with the makeUnitrimArr function
-	needArray := makeUnitrimArr(encoder)
-
-	// check that the need array is the same as the unitrim array
-	fmt.Printf("Need array length: %d, unitrim array length: %d\n", len(needArray), len(unitrim))
-	if len(needArray) != len(unitrim) {
-		t.Errorf("Need array and unitrim array are not the same length\n")
-	}
-
-	for i := range needArray {
-		if needArray[i] != unitrim[i] {
-			fmt.Printf("Need array: %v and unitrim array: %v at index %d are not the same\n", needArray[i], unitrim[i], i)
-			fmt.Printf("mismatched unicode is: %c\n", rune(needArray[i]))
-			t.Errorf("Need array and unitrim array are not the same\n")
+		// make sure the files exist
+		if _, err := os.Stat(encoderFile); os.IsNotExist(err) {
+			t.Errorf("Could not find file %s\n", encoderFile)
 		}
+		if _, err := os.Stat(unitrimFile); os.IsNotExist(err) {
+			t.Errorf("Could not find file %s\n", unitrimFile)
+		}
+
+		// read in the Encoder and unitrim files
+		encoderBytes, err := os.ReadFile(encoderFile)
+		// unmarshal the Encoder file
+		var encoder map[string]Token
+		err = json.Unmarshal(encoderBytes, &encoder)
+		if err != nil {
+			t.Errorf("Could not unmarshal Encoder file: %v\n", err)
+		}
+
+		// read in the unitrim file
+		unitrimBytes, err := os.ReadFile(unitrimFile)
+		// unmarshal the unitrim file
+		var unitrim []int
+		err = json.Unmarshal(unitrimBytes, &unitrim)
+		if err != nil {
+			t.Errorf("Could not unmarshal unitrim file: %v\n", err)
+		}
+
+		// get generated array for unitrim with the makeUnitrimArr function
+		generatedArray := makeUnitrimArr(encoder)
+
+		// check that the generated array is the same as the unitrim array
+		fmt.Printf("Generated array length: %d, unitrim array length: %d\n", len(generatedArray), len(unitrim))
+		if len(generatedArray) != len(unitrim) {
+			t.Errorf("Generated array and unitrim array are not the same length\n")
+		}
+
+		for i := range generatedArray {
+			if generatedArray[i] != unitrim[i] {
+				fmt.Printf("Generated array: %v and unitrim array: %v at index %d are not the same\n", generatedArray[i], unitrim[i], i)
+				fmt.Printf("mismatched unicode is: %c\n", rune(generatedArray[i]))
+				t.Errorf("Generated array and unitrim array are not the same\n")
+			}
+		}
+
+		fmt.Printf("Length and contents of generated array and unitrim array are the same\n")
 	}
-
-	fmt.Printf("Length and contents of need array and unitrim array are the same\n")
-
 }
 
 func TestGPTDecoder_Decode(t *testing.T) {

--- a/resources/resolver.go
+++ b/resources/resolver.go
@@ -631,7 +631,7 @@ type SpecialConfig struct {
 }
 
 // ResolveConfig
-// Resolves a given vocabulary id, and returns the corresonding HuggingFace
+// Resolves a given vocabulary id, and returns the corresponding HuggingFace
 // configuration, and the resources for the tokenizer.
 func ResolveConfig(vocabId string, token string) (config *HFConfig,
 	resources *Resources, err error) {
@@ -882,26 +882,26 @@ func FindNumberOfShardsFromConfig(configPath string) (int, error) {
 	}
 
 	// Access the data at the specified path
-	weight_map, ok := data["weight_map"].(map[string]interface{})
+	weightMap, ok := data["weight_map"].(map[string]interface{})
 	if !ok {
 		fmt.Println("Error: Could not convert data to weight_map")
-		return -1, errors.New(" could not convert data to weight_map")
+		return -1, errors.New("could not convert data to weight_map")
 	}
-	embed_out, ok := weight_map["embed_out.weight"]
+	embedOut, ok := weightMap["embed_out.weight"]
 	if !ok {
 		fmt.Println("Error: Could not convert weight_map to embed_out")
 
-		return -1, errors.New(" could not convert weight_map to embed_out")
+		return -1, errors.New("could not convert weight_map to embed_out")
 	}
-	r, _ := regexp.Compile(`[^\d]*[\d]+[^\d]+([\d]+)`)
+	r, _ := regexp.Compile(`\D*\d+\D+(\d+)`)
 	// convert to interface -> string -> int
-	embed_out_int, err := strconv.Atoi(
-		r.FindStringSubmatch(fmt.Sprintf("%v", embed_out))[1])
+	embedOutInt, err := strconv.Atoi(
+		r.FindStringSubmatch(fmt.Sprintf("%v", embedOut))[1])
 
 	if err != nil {
 		fmt.Println("Error: Could not convert embed_out to int")
-		return -1, errors.New(" could not convert embed_out to int")
+		return -1, errors.New("could not convert embed_out to int")
 	}
 
-	return embed_out_int, nil
+	return embedOutInt, nil
 }

--- a/resources/resolver.go
+++ b/resources/resolver.go
@@ -748,8 +748,7 @@ func ResolveVocabId(vocabId string, token string) (*HFConfig, *Resources, error)
 	} else {
 		config.ModelId = &resolvedVocabId
 		if _, exists := (*resources)["encoder.json"]; !exists {
-			(*resources)["encoder.json"] = *GetEmbeddedResource(
-				"gpt2-tokenizer/encoder.json")
+			(*resources)["encoder.json"] = (*resources)["vocab.json"]
 		}
 		return config, resources, nil
 	}


### PR DESCRIPTION
## `encoder.json` Handling & Unitrim
`encoder.json` handling historically has not made much sense:
1. `encoder.json` represents the exact same content as `vocab.json`.
2. `vocab.json` and `encoder.json` are both populated from the `encoder.json` file when using the embedded tokenizers during `ResolveVocabId()`.
3. However, for custom tokenizers, down in `ResolveResources()`:
  a. `vocab.json` and `encoder.json` are attempted to be read from separate files.
  b. `vocab.json` is generated from `tokenizer.json` if it doesn't exist.
  c. Meanwhile, `encoder.json` is left blank if it doesn't exist.
    1. ...Until `ResolveVocabId()`, where it is set to `gpt2-tokenizer/encoder.json` if it doesn't exist, in spite of any present `vocab.json`.
4. The `encoder.json` resource is then only used for unitrim.
5. `vocab.json` is used for everything else.

Instead of that artificial distinction, there should really only be a single `vocab.json` resource that gets populated by a file with either name, and that one should be used for everything. To that end, this PR implements resource aliases, and sets the filename `encoder.json` as an alias of `vocab.json`.
Accordingly, `"encoder.json"` is no longer a valid resource key in the code, and can now be accessed instead only as `"vocab.json"`.

## Unitrim

Since the `encoder.json` resource used for unitrim was set and used differently than the (usually correct) `vocab.json` for non-embedded tokenizers, the unitrim implementation was wrong for pile models such as the [Pythia Scaling Suite](https://github.com/EleutherAI/pythia) unless you explicitly specified the `pile` embedded tokenizer. For example, in the pile vocabulary, asterisms are a multi-token sequence (`25086` `213`); the existing unitrim code would incorrectly interpret those as GPT2 tokens with the same IDs (e.g. `25086` = "irrational"), and then give an answer that had no connection to the correctly decoded text.
This is now fixed, as the same `vocab.json` resource used for everything else is now also used for unitrim array generation.

The `makeUnitrimArr()` function has additionally been reworked to perform fewer unused computations.

## Other bugs

- The `-show_contexts` flag for the dataset tokenizer didn't work with embedded tokenizers because it didn't use the `InitTokenizer()` logic normally used to initialize a tokenizer when it created one for decoding.
  - This is patched by switching its initialization to use the `InitTokenizer()` function.
  - This is still missing other post-initialization modifications performed (separately) in `TokenizeTextsToContexts()` and `TokenizeTexts()`.
    - As an aside, tokenizer initialization should probably be changed to be done in only one place (or at least cached), since it seems like there is a decent bit of duplicated (but slightly different?) code for it at the moment across `dataset_tokenizer.go`.
    - It currently goes through the whole initialization process like 3 or 4 separate times (which can make the console logging look pretty weird, too).
- `InitTokenizer()` also had a bug where it would load a tokenizer out of a directory ending in the name `<path>-tokenizer` (if it existed) rather than the path specified in an attempt to load an embedded tokenizer.
  - This doesn't seem *likely* to succeed, but it would be very confusing if it did.
  - It now uses `EmbeddedDirExists()` from `gpt_bpe/resources` to check for the existence of an embedded tokenizer directly.
- `InitTokenizer()` also used `log.Fatal` when encountering an error instead of returning one, which would end the program instantly with `os.Exit()`.
  - It now simply returns its errors, as its function signature suggests.
  - This bug also appears in a few places in `gpt_bpe.go`, and has not been patched yet there.