### PR TITLE
Refactor GPT_BPE tokenizer file loading and initial processing

### DIFF
--- a/gpt_bpe.go
+++ b/gpt_bpe.go
@@ -338,9 +338,10 @@ func NewEncoder(vocabId string) (*GPTEncoder, error) {
 	}
 
 	if specialConfig.EncloseEosBos {
-		eosBosBool := true
-		hfConfig.AddBosToken = &eosBosBool
-		hfConfig.AddEosToken = &eosBosBool
+		bosBool := true
+		eosBool := true
+		hfConfig.AddBosToken = &bosBool
+		hfConfig.AddEosToken = &eosBool
 	}
 
 	// Add in default pad token if not already set

--- a/gpt_bpe_test.go
+++ b/gpt_bpe_test.go
@@ -884,6 +884,29 @@ func TestReadTokenizerConfig(t *testing.T) {
 	fmt.Println("All Exists - Looks good.")
 }
 
+func TestPythiaRemoteDownloadTokenizer(t *testing.T) {
+	// Tests the ability to download a tokenizer from a remote model
+	// and use it to encode and decode strings
+	modelId := "EleutherAI/pythia-70m"
+	destPath := "./TestPythiaRemoteDownloadTokenizer"
+	defer os.RemoveAll(destPath)
+	encoderPythia, err := NewEncoder(modelId)
+	if err != nil {
+		t.Errorf("Error creating encoder: %v", err)
+	}
+
+	// Attempt to tokenize
+	testString := "The fox jumped over the hare.\nThe turtle is faster than the hare."
+
+	// Encode the string
+	encoded := encoderPythia.Encode(&testString)
+	// Check that the encoded string is the same as the expected - Reference from python's transformers lib
+	expected := Tokens{510, 30013, 16780, 689, 253, 419, 250, 15, 187, 510, 45993, 310, 7938, 685, 253, 419, 250, 15}
+	if !assert.Equal(t, expected, *encoded) {
+		t.Errorf("Expected: %v\nActual: %v", expected, *encoded)
+	}
+}
+
 func TestGPTDecoder_Decode(t *testing.T) {
 	// TBD
 }

--- a/resources/resolver.go
+++ b/resources/resolver.go
@@ -805,7 +805,9 @@ func ResolveHFFromResources(resources *Resources, hfConfig *HFConfig) (*HFConfig
 // resolveTokenIds
 // Resolve token ids for eos, bos, and pad tokens from resources.
 func resolveTokenIds(resources *Resources, hfConfig *HFConfig) (*HFConfig, error) {
-	// Use interfaces to unmarshal the vocab file from resources
+	// Vocab is stored in either the vocab.json or encoder.json file
+	// We want to unmarshal the vocab file into an interface to work with
+	// We attempt to unmarshal under the vocab.json key first, then encoder.json if it fails
 	var vocab interface{}
 	if _, err := resources.GetFile("vocab.json"); err == nil {
 		if err := json.Unmarshal(*((*resources)["vocab.json"]).Data, &vocab); err != nil {
@@ -859,10 +861,10 @@ func resolveTokenIds(resources *Resources, hfConfig *HFConfig) (*HFConfig, error
 // Used to be able to resolve both embedded and local resources.
 // Continuation of ResolveHFFromResources.
 func resolveVocabSize(resources *Resources, hfConfig *HFConfig) (*HFConfig, error) {
-	// Use interfaces to unmarshal the vocab file
 	var vocab interface{}
-	// If exists, unmarshal vocab.json, else
-	// use GetFile to get the file, then unmarshal it
+	// Vocab is stored in either the vocab.json or encoder.json file
+	// We want to unmarshal the vocab file into an interface to work with
+	// We attempt to unmarshal under the vocab.json key first, then encoder.json if it fails
 	if _, err := resources.GetFile("vocab.json"); err == nil {
 		if err := json.Unmarshal(*((*resources)["vocab.json"]).Data, &vocab); err != nil {
 			fmt.Errorf("Error unmarshalling vocab.json: %s", err)

--- a/resources/resolver.go
+++ b/resources/resolver.go
@@ -881,12 +881,14 @@ func resolveVocabSize(resources *Resources, hfConfig *HFConfig) (*HFConfig, erro
 
 	// Get length of vocab
 	var vocabLen *uint16
-	if vocab != nil {
-		if vocabMap, ok := vocab.(map[string]interface{}); ok {
-			vocabLen = new(uint16)
-			*vocabLen = uint16(len(vocabMap))
-		}
+	if vocab == nil {
+		return nil, errors.New("vocab file not found")
 	}
+	if vocabMap, ok := vocab.(map[string]interface{}); ok {
+		vocabLen = new(uint16)
+		*vocabLen = uint16(len(vocabMap))
+	}
+
 	hfConfig.VocabSize = vocabLen
 	return hfConfig, nil
 }

--- a/resources/resolver.go
+++ b/resources/resolver.go
@@ -823,33 +823,30 @@ func resolveTokenIds(resources *Resources, hfConfig *HFConfig) (*HFConfig, error
 		}
 	}
 
-	// Get the token ids for eos, bos, and pad tokens
-	if vocab != nil {
-		if vocabMap, ok := vocab.(map[string]interface{}); ok {
-			if hfConfig.EosTokenStr != nil {
-				if eosToken, ok := vocabMap[*(hfConfig.EosTokenStr)]; ok {
-					if eosTokenInt, ok := eosToken.(float64); ok {
-						hfConfig.EosTokenId = new(uint16)
-						*hfConfig.EosTokenId = uint16(eosTokenInt)
-					}
-				}
-			}
-			if hfConfig.BosTokenStr != nil {
-				if bosToken, ok := vocabMap[*(hfConfig.BosTokenStr)]; ok {
-					if bosTokenInt, ok := bosToken.(float64); ok {
-						hfConfig.BosTokenId = new(uint16)
-						*hfConfig.BosTokenId = uint16(bosTokenInt)
-					}
-				}
-			}
+	// If vocab is nil, return an error
+	if vocab == nil {
+		return nil, errors.New("vocab file not found")
+	}
 
-			if hfConfig.PadTokenStr != nil {
-				if padToken, ok := vocabMap[*(hfConfig.PadTokenStr)]; ok {
-					if padTokenInt, ok := padToken.(float64); ok {
-						hfConfig.PadTokenId = new(uint16)
-						*hfConfig.PadTokenId = uint16(padTokenInt)
-					}
-				}
+	// Get the token ids for eos, bos, and pad tokens
+	if vocabMap, ok := vocab.(map[string]interface{}); ok {
+		if hfConfig.EosTokenStr != nil {
+			if eosTokenInt, ok := vocabMap[*(hfConfig.EosTokenStr)].(float64); ok {
+				hfConfig.EosTokenId = new(uint16)
+				*hfConfig.EosTokenId = uint16(eosTokenInt)
+			}
+		}
+		if hfConfig.BosTokenStr != nil {
+			if bosTokenInt, ok := vocabMap[*(hfConfig.BosTokenStr)].(float64); ok {
+				hfConfig.BosTokenId = new(uint16)
+				*hfConfig.BosTokenId = uint16(bosTokenInt)
+			}
+		}
+
+		if hfConfig.PadTokenStr != nil {
+			if padTokenInt, ok := vocabMap[*(hfConfig.PadTokenStr)].(float64); ok {
+				hfConfig.PadTokenId = new(uint16)
+				*hfConfig.PadTokenId = uint16(padTokenInt)
 			}
 		}
 	}

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -92,8 +92,6 @@ func FetchHTTP(uri string, rsrc string, auth string) (io.ReadCloser, error) {
 			resp.StatusCode))
 	}
 	return resp.Body, nil
-
-	// testing copilot:
 }
 
 // SizeHTTP

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -92,6 +92,8 @@ func FetchHTTP(uri string, rsrc string, auth string) (io.ReadCloser, error) {
 			resp.StatusCode))
 	}
 	return resp.Body, nil
+
+	// testing copilot:
 }
 
 // SizeHTTP


### PR DESCRIPTION

## Summary
This PR and following will aim to address gpt_bpe's confusing structure of file loading and initial processing during the process of creating an encoder. It aims to meet the code quality requirements to be merged back upstream to wbrown/gpt_bpe .


## Changes
GPT_BPE is able to create an encoder using files from embedded, local, or remote. Previously, embedded and local/remote had two separate but parallel code paths related to file loading and initial processing which caused duplication of code. In this PR, I have separated this code into a single step for loading resources and a single step for initial processing.

I have also removed the mistral specific config structs in favor of expanding the hfconfig struct.

I have also added a test case that downloads pythia-70m remotely (not embedded) and tests the functionality of the pythia provided tokenizer against a reference generated by python transformer library. 